### PR TITLE
Fix Formulario visibility

### DIFF
--- a/libreta.java
+++ b/libreta.java
@@ -568,10 +568,8 @@ class Formulario extends JFrame {
         Inferior.add (botcrearnota);
   
 
-       
         //Cierre
-        
-        Formulario.this.dispose(); 
+
         this.setVisible(true);
     }
 }


### PR DESCRIPTION
## Summary
- keep `Formulario` window visible by removing dispose call

## Testing
- `javac libreta.java` *(fails: class Libreta is public, should be declared in a file named Libreta.java)*

------
https://chatgpt.com/codex/tasks/task_e_6844a4a875708320834b374331b0e6b3