### PR TITLE
Fix shortcut comments

### DIFF
--- a/libreta.java
+++ b/libreta.java
@@ -339,7 +339,7 @@ class Formulario extends JFrame {
             }
         });
 
-        // Ctrl + Shift: cambiar al siguiente color
+        // Alt + C: cambiar al siguiente color
         campotxt.getInputMap().put(KeyStroke.getKeyStroke("alt C"), "siguienteColor");
         campotxt.getActionMap().put("siguienteColor", new AbstractAction() {
             @Override
@@ -358,7 +358,7 @@ class Formulario extends JFrame {
             }
         });
 
-        // Ctrl + Tab: cambiar al color "Sin destacar"
+        // Alt + X: cambiar al color "Sin destacar"
         campotxt.getInputMap().put(KeyStroke.getKeyStroke("alt X"), "colorSinDestacar");
         campotxt.getActionMap().put("colorSinDestacar", new AbstractAction() {
             @Override
@@ -729,7 +729,7 @@ class VentanaNota extends JFrame {
             }
         });
 
-        // Ctrl + Shift: cambiar al siguiente color
+        // Alt + C: cambiar al siguiente color
         areatexto.getInputMap().put(KeyStroke.getKeyStroke("alt C"), "siguienteColor");
         areatexto.getActionMap().put("siguienteColor", new AbstractAction() {
             @Override
@@ -748,7 +748,7 @@ class VentanaNota extends JFrame {
             }
         });
 
-        // Ctrl + Tab: cambiar al color "Sin destacar"
+        // Alt + X: cambiar al color "Sin destacar"
         areatexto.getInputMap().put(KeyStroke.getKeyStroke("alt X"), "colorSinDestacar");
         areatexto.getActionMap().put("colorSinDestacar", new AbstractAction() {
             @Override


### PR DESCRIPTION
## Summary
- update the keyboard shortcut comments in `Formulario` and `VentanaNota`

## Testing
- `javac libreta.java` *(fails: class name mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6844a4ac97a88320b035c097146657b5