### PR TITLE
Fix typo in comment

### DIFF
--- a/libreta.java
+++ b/libreta.java
@@ -48,7 +48,7 @@ public class Libreta {
 		mainmenu.setAlwaysOnTop(true);
 		mainmenu.getContentPane().setLayout(new BoxLayout(mainmenu.getContentPane(), BoxLayout.Y_AXIS)); //para clase main
                
-        //Funcionamaniento de botones
+        //Funcionamiento de botones
         JButton boton1 = new JButton("Agregar Nota");
 
 


### PR DESCRIPTION
## Summary
- fix typo in libreta comment near button functionality

## Testing
- `javac libreta.java` *(fails: class name doesn't match file name)*

------
https://chatgpt.com/codex/tasks/task_e_6844a4a16cbc8320b496f8158ed956ed